### PR TITLE
Do not read stderr in runDBCommand()

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -133,7 +133,7 @@ def runDBCommand(command):
     returncode = None
     line = ""
     try:
-        create_process = subprocess.Popen(command, env=os.environ, shell=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+        create_process = subprocess.Popen(command, env=os.environ, shell=True, stdout=subprocess.PIPE)
         while True:
             returncode = create_process.poll()
             line += create_process.stdout.readline()     


### PR DESCRIPTION
Fixes a problem with MySQL v5.6 that prints 'Warning: Using a password on the command line interface can be insecure.' in stderr upon all connections.

With this fix, all DB errors and warnings will not be read by the migrate module but seen directly in the console when migrate is run.

Without this fix, migrate does not know how to handle the MySQL warning and all migrations to MySQL 5.6 fail like this:
~ Database migration:
~
~    Database: foodb (Alias:db1)
~    Version: Warning:
~    Status: Using a password on the command line interface can be insecure. 53 Successful
Traceback (most recent call last):
  File "/Users/ykar/Programs/play-1.2.5/play", line 153, in <module>
    status = cmdloader.commands[play_command].execute(command=play_command, app=play_app, args=remaining_args, env=play_env, cmdloader=cmdloader)
  File "/Users/ykar/Projects/test/modules/migrate-1.4/commands.py", line 425, in execute
    up()
  File "/Users/ykar/Projects/test/modules/migrate-1.4/commands.py", line 340, in up
    [maxindex, files_obj] = getMigrateFiles(db_alias,int(version))
ValueError: invalid literal for int() with base 10: 'Warning:'
